### PR TITLE
added: backslash as an escape character in markdown mode for * and _

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -22,6 +22,11 @@ function markdownToHtml( text ) {
         .replace( />/gm, '&gt;' )
         // span
         .replace( /&lt;\s?span([^\/\n]*)&gt;((?:(?!&lt;\/).)+)&lt;\/\s?span\s?&gt;/gm, _createSpan )
+        // "\" will be used as escape character for *, _
+        .replace( /&/gm, '&amp;' )
+        .replace( /\\\\/gm, '&92;' )
+        .replace( /\\\*/gm, '&42;' )
+        .replace( /\\_/gm, '&95;' )
         // strong
         .replace( /__(.*?)__/gm, '<strong>$1</strong>' )
         .replace( /\*\*(.*?)\*\*/gm, '<strong>$1</strong>' )
@@ -37,6 +42,11 @@ function markdownToHtml( text ) {
         .replace( /(\n(\*|\+|-) (.*))+$/gm, _createUnorderedList )
         // ordered lists (in JS $ matches end of line as well as end of string)
         .replace( /(\n([0-9]+\.) (.*))+$/gm, _createOrderedList )
+        // reverting escape of special characters
+        .replace( /&95;/gm, '_' )
+        .replace( /&92;/gm, '\\' )
+        .replace( /&42;/gm, '*' )
+        .replace( /&amp;/gm, '&' )
         // paragraphs
         .replace( /([^\n]+)\n/gm, _createParagraph );
 

--- a/test/markdown.spec.js
+++ b/test/markdown.spec.js
@@ -106,6 +106,24 @@ describe( 'markdown', function() {
             [ '<span style="color:red;">_dbl_</span>', '<span style="color:red;"><em>dbl</em></span>' ],
             [ 'list:\n* __a__\n* _b_ \n+ [c](c)', 'list:<ul><li><strong>a</strong></li><li><em>b</em></li><li><a href="c" target="_blank">c</a></li></ul>' ],
             [ '<span style="color:blue">[link](http://enketo.org)</span>', '<span style="color:blue"><a href="http://enketo.org" target="_blank">link</a></span>' ],
+            // escaping special characters with backslash
+            [ 'A\\_B\\_C', 'A_B_C' ],
+            [ '_A\\_B\\_C_', '<em>A_B_C</em>' ],
+            [ 'A_B\\_C', 'A_B_C' ],
+            [ 'A\\_B_C', 'A_B_C' ],
+            [ 'A_B_C', 'A<em>B</em>C' ],
+            [ '\\__AB\\__', '_<em>AB_</em>' ],
+            [ '\\\\_AB\\_\\\\_', '\\<em>AB_\\</em>' ],
+            [ 'A\\*B\\*C', 'A*B*C' ],
+            [ '*A\\*B\\*C*', '<em>A*B*C</em>' ],
+            [ 'A*B\\*C', 'A*B*C' ],
+            [ 'A*B*C', 'A<em>B</em>C' ],
+            [ '\\**AB\\**', '*<em>AB*</em>' ],
+            [ '\\\\*AB\\*\\\\*', '\\<em>AB*\\</em>' ],
+            [ '\\a\\ b\\*c\\d\\_e', '\\a\\ b*c\\d_e' ],
+            [ '\\', '\\' ],
+            [ '\\\\', '\\' ],
+            [ '\\\\\\', '\\\\' ],
         ].forEach( function( test ) {
             var source = test[ 0 ];
             var expected = ( typeof test[ 1 ] !== 'undefined' ) ? test[ 1 ] : test[ 0 ];


### PR DESCRIPTION
Initial proposal for #36 

I have opted for escaping only `*` and `_` for now. I'd like to include `#` in there, and use typical `&#NN;` html escape syntax, but that will require some adjustments in regexes for current markdown rules for headers.

Changes so far impact two previous tests - one in markdown, where `&lt;span&gt;a&lt;/span&gt;` by old logic is replaced by `'<span>a</span>'`, and with above changes the result is `&lt;span&gt;a&lt;/span&gt;`. I'm not sure if the old behavior should be preserved in this case, since with new result the input is properly escaped.
Similarly, second failing test case is in transformer tests and portrays the same issue.

