### PR TITLE
Make it clearer which app has started in logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,5 +17,5 @@ app.use( bodyParser.urlencoded( {
 require( './src/api' )( app );
 
 app.listen( app.get( 'port' ), function() {
-    console.log( 'app running on port ' + app.get( 'port' ) + '!' );
+    console.log( 'enketo-transformer running on port ' + app.get( 'port' ) + '!' );
 } );


### PR DESCRIPTION
Now that `npm start` in enketo-core starts both services, the old message is a little misleading 🙂 
