### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal
+
+WORKDIR /vagrant
+COPY . .
+RUN QUIET=true MINIMAL=true . setup/bootstrap.sh
+
+EXPOSE 8085
+CMD ["npm", "start"]

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -3,6 +3,8 @@
 # exit if an error occurs
 set -e
 
+export DEBIAN_FRONTEND=noninteractive
+
 # installing prerequisites
 echo 'installing prerequisites...'
 apt-get update
@@ -19,6 +21,16 @@ if [ -d "/vagrant/node_modules" ]; then
 fi
 npm install
 npm install -g mocha
+
+if [ "$MINIMAL" = "true" ]
+then
+    apt-get remove -y build-essential
+    apt-get autoremove -y
+fi
+if [ "$QUIET" = "true" ]
+then
+    exit 0
+fi
 
 echo "*************************************************************************************"
 echo "***                           Development VM created!                             ***"


### PR DESCRIPTION
The idea is to reuse the existing `setup/bootstrap.sh` script made for Vagrant, to avoid redundant code or untested  custom bits. Vagrant VM and the Dockerfile are very much aligned.

It works well with PR #94 and PR #95.