### PR TITLE
Change form id attribute to form-id to support spaces

### DIFF
--- a/src/xsl/openrosa2html5form.xsl
+++ b/src/xsl/openrosa2html5form.xsl
@@ -105,13 +105,13 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
                             <xsl:value-of select="concat(' ', /h:html/h:body/@class)" />
                         </xsl:if>
                     </xsl:attribute>
-                    <xsl:attribute name="id">
+                    <xsl:attribute name="data-form-id">
                         <xsl:choose>
                             <xsl:when test="/h:html/h:head/xf:model/xf:instance[1]/child::node()/@id">
-                                <xsl:value-of select="translate(/h:html/h:head/xf:model/xf:instance/child::node()/@id, ' ', '_' )" /><!-- not smart! -->
+                                <xsl:value-of select="/h:html/h:head/xf:model/xf:instance/child::node()/@id" />
                             </xsl:when>
                             <xsl:when test="/h:html/h:head/xf:model/xf:instance/child::node()/@xmlns">
-                                <xsl:value-of select="translate(/h:html/h:head/xf:model/xf:instance/child::node()/@xmlns, ' ', '_')" />
+                                <xsl:value-of select="/h:html/h:head/xf:model/xf:instance/child::node()/@xmlns" />
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:text>_</xsl:text>

--- a/test/forms/form-id-with-accent.xml
+++ b/test/forms/form-id-with-accent.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Geotrace and shape</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="Éphémère" version="foo">
+                    <thing/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/thing" type="string"/>
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/thing">
+            <label>Thing</label>
+        </input>
+    </h:body>
+</h:html>

--- a/test/forms/form-id-with-space.xml
+++ b/test/forms/form-id-with-space.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Geotrace and shape</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="FormId with spaces" version="foo">
+                    <thing/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/thing" type="string"/>
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/thing">
+            <label>Thing</label>
+        </input>
+    </h:body>
+</h:html>

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -58,6 +58,30 @@ describe( 'transformer', () => {
         } );
     } );
 
+    describe( 'puts attributes on root', () => {
+        it( 'copies the formId', () => {
+            const xform = fs.readFileSync( './test/forms/widgets.xml', 'utf8' );
+            const result = transformer.transform( { xform } );
+
+            return expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'data-form-id="widgets"' );
+        } );
+
+        it( 'copies the formId with accents', () => {
+            const xform = fs.readFileSync( './test/forms/form-id-with-accent.xml', 'utf8' );
+            const result = transformer.transform( { xform } );
+
+            return expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'data-form-id="Éphémère"' );
+        } );
+
+        // https://github.com/enketo/enketo-transformer/issues/100
+        it( 'copies the formId with spaces', () => {
+            const xform = fs.readFileSync( './test/forms/form-id-with-space.xml', 'utf8' );
+            const result = transformer.transform( { xform } );
+
+            return expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'data-form-id="FormId with spaces"' );
+        } );
+    } );
+
     describe( 'copies attributes on the `<model>`', () => {
         it( 'copies the odk:xforms-version attribute', () => {
             const xform = fs.readFileSync( './test/forms/autocomplete.xml', 'utf8' );


### PR DESCRIPTION
Closes #100 

As discussed in #100, spaces were previously replaced because the `id` attribute is well-known in HTML and is not supposed to contain spaces. This PR introduces a custom attribute named `form-id` with no value restrictions and removes the `id` attribute.

We discussed just using spaces in the `id` attribute value but the risk there is that some browser e.g. chooses to truncate on the space now or in the future. There is value to putting an `id` on a `form` but only [to have form elements outside the `form` block](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefform) or to apply a style (hard to do when the id is dynamically generated; if there's only one `form`, seems using the element name is better). If this were desirable in some future, `id` could be added back in with a transformation to replace spaces (or just using something static and generic like `form1`).

As far as I can tell, the form id is only used to communicate with other Enketo tools so changing the attribute name is not a big deal. I briefly looked at [dependent packages](https://github.com/enketo/enketo-transformer/network/dependents?package_id=UGFja2FnZS0xODA5ODgxMA%3D%3D) and they're all either core Enketo tools, forks of core Enketo tools, or no longer maintained. Still, it is a breaking change. We could also keep the `id` element as-is for backwards compatibility.

I'll follow up with PRs to update dependent tools using a to-be-released v1.43.0.

(Side note. Technically the `id` and `xmlns` blocks are in the wrong order: "If specified, the id value takes precedence over any explicit xmlns declaration." [source](https://docs.getodk.org/openrosa-metadata/#form-identity). Don't think this matters much since I've never seen a form that uses a namespace for this but I can flip them in this PR if desired.)
