### PR TITLE
Escape spaces in jr: media URLs

### DIFF
--- a/test/forms/jr-url-space.xml
+++ b/test/forms/jr-url-space.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>jr-url-space</h:title>
+        <model>
+            <itext>
+                <translation default="true()" lang="English">
+                    <text id="/outside/l1:label">
+                        <value form="image">jr://images/hallo spaceboy/spiders from mars.jpg</value>
+                    </text>
+                    <text id="/outside/l2:label">
+                        <value form="audio">jr://audio/hallo spaceboy/space oddity.mp3</value>
+                    </text>
+                    <text id="/outside/l3:label">
+                        <value form="video">jr://video/hallo spaceboy/a small plot of land.mp4</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <outside>
+                    <a/>
+                    <b/>
+                    <c>jr://images/hallo spaceboy/under pressure.png</c>
+                    <l1/>
+                    <l2/>
+                    <l2/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </outside>
+            </instance>
+            <bind nodeset="/outside/a" type="string"/>
+            <bind nodeset="/outside/b" type="string"/>
+            <bind nodeset="/outside/c" type="binary"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/a">
+            <label ref="jr:itext('/outside/l1:label')"/>
+        </input>
+        <input ref="/b">
+            <label ref="jr:itext('/outside/l2:label')"/>
+        </input>
+        <upload appearance="annotate" mediatype="image/*" ref="/outside/c">
+            <label ref="jr:itext('/outside/l3:label')"/>
+        </upload>
+    </h:body>
+</h:html>

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -324,6 +324,32 @@ describe( 'transformer', () => {
             ] );
         } );
 
+
+        it( 'escapes spaces in URLs', () => {
+            const xform = fs.readFileSync( './test/forms/jr-url-space.xml', 'utf8' );
+            const media = {
+                'hallo spaceboy/spiders from mars.jpg': 'hallo spaceboy/spiders from mars.jpg',
+                'hallo spaceboy/space oddity.mp3': 'hallo spaceboy/space oddity.mp3',
+                'hallo spaceboy/under pressure.mp4': 'hallo spaceboy/under pressure.mp4',
+                'hallo spaceboy/a small plot of land.png': 'hallo spaceboy/a small plot of land.png',
+            };
+            const result = transformer.transform( {
+                xform,
+                media
+            } );
+
+            return Promise.all( [
+                expect( result ).to.eventually.have.property( 'form' ).and.to.not.contain( 'jr://images/hallo spaceboy/spiders from mars.jpg' ),
+                expect( result ).to.eventually.have.property( 'form' ).and.to.not.contain( 'jr://audio/hallo spaceboy/space oddity.mp3' ),
+                expect( result ).to.eventually.have.property( 'form' ).and.to.not.contain( 'jr://video/hallo spaceboy/a small plot of land.mp4' ),
+                expect( result ).to.eventually.have.property( 'model' ).and.to.not.contain( 'jr://images/hallo spaceboy/under pressure.png' ),
+
+                expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/spiders%20from%20mars.jpg' ),
+                expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/space%20oddity.mp3' ),
+                expect( result ).to.eventually.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/a%20small%20plot%20of%20land.mp4' ),
+                expect( result ).to.eventually.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/under%20pressure.png' ),
+            ] );
+        } );
     } );
 
     describe( 'processes questions with constraints', () => {


### PR DESCRIPTION
Supports enketo-express#218

- Escapes `jr:` media URLs in the XML model transform
- HTML `src` and `href` attributes were already escaped, but this adds test coverage