### PR TITLE
Cache built modules, run once on release

### DIFF
--- a/.github/workflows/npmjs.yml
+++ b/.github/workflows/npmjs.yml
@@ -1,6 +1,11 @@
 name: npmjs
 
-on: [push, pull_request, release]
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -10,16 +15,23 @@ jobs:
         node: [ '14', '16' ]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: node_modules
+          key: ${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.node }}-
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org/
       - run: npm install -g npm@^6
-      - run: npm ci
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm test
       - run: npm run build-docs
-      - name: Run npm publish
-        if: github.event_name == 'release' && github.event.action == 'created' && matrix.node == '16'
+      - if: github.event_name == 'release' && github.event.action == 'published' && matrix.node == '16'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Fixes #136

Each time you run `npm ci` it throws away `node_modules` which has the specific modules we'd like to cache (libxmljs/libxslt). This approach makes runs `npm ci` when `package-lock.json` changes. I think that's about the best we can do.