### PR TITLE
Fixed mangling of markdown-produced HTML next to top-level text nodes…

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -498,12 +498,15 @@ function _renderMarkdown(htmlDoc, mediaMap) {
 
             if (original !== rendered) {
                 if (mediaMap != null) {
-                    const fragment = libxmljs.parseHtmlFragment(rendered);
+                    const fragment = libxmljs.parseHtmlFragment(
+                        `<div class="temporary-root">${rendered}</div>`
+                    );
 
-                    rendered = _replaceMediaSources(
-                        fragment,
-                        mediaMap
-                    ).toString(false);
+                    rendered = _replaceMediaSources(fragment, mediaMap)
+                        .root()
+                        .childNodes()
+                        .map((node) => node.toString(false))
+                        .join('');
                 }
 
                 key = `$$$${index}`;

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -80,11 +80,15 @@ function transform(survey) {
           }
         : {};
 
-    const mediaMap = Object.fromEntries(
-        Object.entries(survey.media || {}).map((entry) =>
-            entry.map(escapeURLPath)
-        )
-    );
+    let mediaMap = null;
+
+    if (survey.media) {
+        mediaMap = Object.fromEntries(
+            Object.entries(survey.media).map((entry) =>
+                entry.map(escapeURLPath)
+            )
+        );
+    }
 
     return _parseXml(survey.xform)
         .then((doc) => {

--- a/test/forms/bold-media.xml
+++ b/test/forms/bold-media.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:enk="http://enketo.org/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:oc="http://openclinica.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>01Form</h:title>
+		<model odk:xforms-version="1.0.0">
+			<instance>
+				<data id="Bold_issue" version="1">
+					<note/>
+					<meta>
+						<instanceID/>
+					</meta>
+				</data>
+			</instance>
+			<bind nodeset="/data/note" readonly="true()" type="string"/>
+			<bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+			<instance id="_users" src="jr://file/users.xml"/>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/note">
+			<label>**Note with bold** nnnn</label>
+		</input>
+	</h:body>
+</h:html>

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -480,7 +480,10 @@ describe('transformer', () => {
                 './test/forms/bold-media.xml',
                 'utf8'
             );
-            const result = transformer.transform({ xform });
+            const media = {
+                'users.xml': '/path/to/users.xml',
+            };
+            const result = transformer.transform({ xform, media });
             return expect(result)
                 .to.eventually.have.property('form')
                 .and.to.contain('<strong>Note with bold</strong> nnnn');

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -474,6 +474,18 @@ describe('transformer', () => {
             ]);
         });
 
+        // bug https://github.com/enketo/enketo-transformer/issues/149
+        it('without mangling markdown-created HTML elements', () => {
+            const xform = fs.readFileSync(
+                './test/forms/bold-media.xml',
+                'utf8'
+            );
+            const result = transformer.transform({ xform });
+            return expect(result)
+                .to.eventually.have.property('form')
+                .and.to.contain('<strong>Note with bold</strong> nnnn');
+        });
+
         describe('spaces in jr: media URLs', () => {
             const xform = fs.readFileSync(
                 './test/forms/jr-url-space.xml',
@@ -664,6 +676,11 @@ describe('transformer', () => {
                                 .and.to.contain(
                                     'hallo%20spaceboy/wishful%20beginnings.xml'
                                 ),
+
+                            // issue https://github.com/enketo/enketo-transformer/issues/149
+                            expect(result)
+                                .to.have.property('form')
+                                .and.to.contain('markdown</a><br>'),
                         ]);
                     });
                 });


### PR DESCRIPTION
… when a mediamap is provided, closes #149

The argument provided to `parseHtmlFragment` has to be a valid HTML fragment. If the content contains sibling nodes after markdown transformation, the function silently tries to combine the siblings into a single node (I think) in surprising ways.

It seemed best to add a temporary top level root node before parsing and then ignore that node when serializing it again.