### PR TITLE
Fix: regression when no media mapping provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.5] - 2022-05-05
+
+##### Changed
+
+-   Fixed regression when transforming forms with no media mapping, when the form has binary defaults or references jr: URLs in markdown. (#152)
+
 ## [2.1.4] - 2022-05-04
 
 ##### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-transformer",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-transformer",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "Library/app that transforms ODK-compliant XForms into a format that Enketo can consume",
     "license": "Apache-2.0",
     "main": "src/transformer.js",

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -80,15 +80,11 @@ function transform(survey) {
           }
         : {};
 
-    let mediaMap = null;
-
-    if (survey.media) {
-        mediaMap = Object.fromEntries(
-            Object.entries(survey.media).map((entry) =>
-                entry.map(escapeURLPath)
-            )
-        );
-    }
+    const mediaMap = Object.fromEntries(
+        Object.entries(survey.media || {}).map((entry) =>
+            entry.map(escapeURLPath)
+        )
+    );
 
     return _parseXml(survey.xform)
         .then((doc) => {
@@ -501,17 +497,15 @@ function _renderMarkdown(htmlDoc, mediaMap) {
             let rendered = markdown.toHtml(original);
 
             if (original !== rendered) {
-                if (mediaMap != null) {
-                    const fragment = libxmljs.parseHtmlFragment(
-                        `<div class="temporary-root">${rendered}</div>`
-                    );
+                const fragment = libxmljs.parseHtmlFragment(
+                    `<div class="temporary-root">${rendered}</div>`
+                );
 
-                    rendered = _replaceMediaSources(fragment, mediaMap)
-                        .root()
-                        .childNodes()
-                        .map((node) => node.toString(false))
-                        .join('');
-                }
+                rendered = _replaceMediaSources(fragment, mediaMap)
+                    .root()
+                    .childNodes()
+                    .map((node) => node.toString(false))
+                    .join('');
 
                 key = `$$$${index}`;
                 replacements[key] = rendered;

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -731,6 +731,25 @@ describe('transformer', () => {
                     '/hallo%20spaceboy/wishful%20beginnings.xml?p=q&amp;r'
                 );
             });
+
+            // Regression in https://github.com/enketo/enketo-transformer/pull/150.
+            // Before that change, omitting a media mapping would fall back to an empty object
+            // as a default.
+            it('returns an empty media map when none was provided at the call site', async () => {
+                const result = await transformer.transform({ xform });
+
+                expect(result.form).to.contain('jr://images/first%20image.jpg');
+                expect(result.form).to.contain('jr://audio/a%20song.mp3');
+                expect(result.form).to.contain('jr://video/some%20video.mp4');
+                expect(result.model).to.contain(
+                    'jr://images/another%20image.png'
+                );
+                expect(result.model).to.contain('jr://file/an%20instance.xml');
+                expect(result.model).to.contain(
+                    'jr://file-csv/a%20spreadsheet.csv'
+                );
+                expect(result.form).to.contain('jr://file/a%20link.xml');
+            });
         });
     });
 


### PR DESCRIPTION
The change introduced in #150 causes errors/inconsistent URL-escaping behavior when:

- No media mapping is provided by the survey
- A survey includes binary defaults
- A survey references a `jr:` URL in markdown

This fix restores the previous behavior, but incorporates the fix from #150 to prevent incorrectly injecting paragraphs into markdown fragments.