### PR TITLE
Fix: special string.replace sequences in Markdown

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -523,7 +523,12 @@ function _renderMarkdown(htmlDoc, mediaMap) {
         .forEach((key) => {
             const replacement = replacements[key];
             if (replacement) {
-                htmlStr = htmlStr.replace(key, replacement);
+                /**
+                 * The replacement is called as a function here so special string
+                 * replacement sequences are preserved if they appear within Markdown.
+                 *  @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement}
+                 */
+                htmlStr = htmlStr.replace(key, () => replacement);
             }
         });
 

--- a/test/forms/md-str-replace-chars.xml
+++ b/test/forms/md-str-replace-chars.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>md-str-replace-chars</h:title>
+        <model>
+            <itext>
+                <translation default="true()" lang="default">
+                    <text id="special-chars:label">
+                        <value>*$' is $` this $&amp; the $$ real $0 $&lt;life&gt;?*</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <data id="rank">
+                    <special-chars/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/special-chars"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/special-chars">
+            <label ref="jr:itext('special-chars:label')" />
+        </input>
+    </h:body>
+</h:html>

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -257,6 +257,20 @@ describe('transformer', () => {
                     'formatted: <em><span class="or-output" data-value="/output/txt"> </span></em> and'
                 );
         });
+
+        it('preserves text containing special string replacement sequences', async () => {
+            const xform = fs.readFileSync(
+                './test/forms/md-str-replace-chars.xml',
+                'utf8'
+            );
+            const result = await transformer.transform({
+                xform,
+            });
+
+            expect(result.form).to.contain(
+                "<em>$' is $` this $&amp; the $$ real $0 $&lt;life&gt;?</em>"
+            );
+        });
     });
 
     describe('does not render markdown', () => {


### PR DESCRIPTION
Closes #109. Also closes #110, as this incorporates the change I proposed there and adds a test for the fix.

