### PR TITLE
Remove badges for unused services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![coverage-shield-badge-1](https://img.shields.io/badge/coverage-97.86%25-brightgreen.svg)
-[![npm version](https://badge.fury.io/js/enketo-transformer.svg)](http://badge.fury.io/js/enketo-transformer) [![Build Status](https://travis-ci.org/enketo/enketo-transformer.svg?branch=master)](https://travis-ci.org/enketo/enketo-transformer) [![Dependency Status](https://david-dm.org/enketo/enketo-transformer.svg)](https://david-dm.org/enketo/enketo-transformer)
+[![npm version](https://badge.fury.io/js/enketo-transformer.svg)](http://badge.fury.io/js/enketo-transformer)
 
 # Enketo Transformer
 


### PR DESCRIPTION
We don't use Travis for builds anymore. David-dm is either gone or [routinely down](https://github.com/alanshaw/david/issues/171).