### PR TITLE
v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.1] - 2023-02-07
+
+##### Changed
+
+-   Fix: include build artifacts when publishing (#167)
+
 ## [2.2.0] - 2023-02-07
 
 ##### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-transformer",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-transformer",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Library/app that transforms ODK-compliant XForms into a format that Enketo can consume",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
The very recent v2.2.0 release doesn't include build artifacts. That was the first release with a build step and the `.gitignore` prevented the built artifacts from being published.