### PR TITLE
Fix import error for enketo-transformer/web

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
             "types": "./dist/types/src/dom/node/index.d.ts"
         },
         "./web": {
-            "default": "./dist/enketo-transformer/web/transformer.js",
-            "types": "./dist/enketo-transformer/web/src/transformer.d.ts"
+            "types": "./dist/enketo-transformer/web/src/transformer.d.ts",
+            "default": "./dist/enketo-transformer/web/transformer.js"
         }
     },
     "typesVersions": {


### PR DESCRIPTION
Fixes https://github.com/enketo/enketo-transformer/issues/183

Re-ordering of `types` to be before `default` in the web exports.

from https://nodejs.org/api/packages.html#conditional-exports:

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.