### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ const result = await transform({
 
 **Note:** because `preprocess` depends on `libxmljs` which is only available for Node, `preprocess` is also not supported on the web. If you must preprocess an XForm before it is transformed, you may do that before calling `transform`.
 
+If your project uses Webpack or another bundler, you may need to [tell it to ignore the `libxslt` package](https://github.com/enketo/enketo-transformer/issues/185#issuecomment-1802426670).
+
 ## Development/local usage
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Install Enketo Transformer with:
 npm install enketo-transformer
 ```
 
-*If you face issues during installation:* Verify that [these requirements](https://github.com/nodejs/node-gyp#on-unix) are met. We depend on upstream XSLT and XML C++ libraries that require compilation upon installation using [node-gyp](https://github.com/nodejs/node-gyp).
-
 ### Node
 
 ```ts


### PR DESCRIPTION
- Remove note about node-gyp issues during installation.
Since libxslt is now an optional peer dependency, it will not be installed along with enketo-transformer, so this note is irrelevant.
In 'Prerequisites', we tell people to install libxslt separately (if necessary) and we do inform them of the requirements there.
- Add note that may help people experiencing https://github.com/enketo/enketo/issues/758